### PR TITLE
s/chars/bytes/ for ~10% better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ use gtrie::Trie;
 
 let mut t = Trie::new();
 
-t.insert("this".chars(), 1);
-t.insert("trie".chars(), 2);
-t.insert("contains".chars(), 3);
-t.insert("a".chars(), 4);
-t.insert("number".chars(), 5);
-t.insert("of".chars(), 6);
-t.insert("words".chars(), 7);
+t.insert("this".bytes(), 1);
+t.insert("trie".bytes(), 2);
+t.insert("contains".bytes(), 3);
+t.insert("a".bytes(), 4);
+t.insert("number".bytes(), 5);
+t.insert("of".bytes(), 6);
+t.insert("words".bytes(), 7);
 
-assert_eq!(t.contains_key("number".chars()), true);
-assert_eq!(t.contains_key("not_existing_key".chars()), false);
-assert_eq!(t.get_value("words".chars()), Some(7));
-assert_eq!(t.get_value("none".chars()), None);
+assert_eq!(t.contains_key("number".bytes()), true);
+assert_eq!(t.contains_key("not_existing_key".bytes()), false);
+assert_eq!(t.get_value("words".bytes()), Some(7));
+assert_eq!(t.get_value("none".bytes()), None);
 ```
 
 # Benchmarks

--- a/benches/basic_benchmark.rs
+++ b/benches/basic_benchmark.rs
@@ -25,10 +25,10 @@ fn generate_keys() -> Vec<String> {
 fn trie_match(b: &mut Bencher) {
     let mut t = gtrie::Trie::new();
 
-    t.insert("test".chars(), String::from("test"));
+    t.insert("test".bytes(), String::from("test"));
 
     b.iter(|| {
-        assert_eq!(t.contains_key("test".chars()), true);
+        assert_eq!(t.contains_key("test".bytes()), true);
     })
 }
 
@@ -36,10 +36,10 @@ fn trie_match(b: &mut Bencher) {
 fn trie_mismatch(b: &mut Bencher) {
     let mut t = gtrie::Trie::new();
 
-    t.insert("test".chars(), String::from("test"));
+    t.insert("test".bytes(), String::from("test"));
 
     b.iter(|| {
-        assert_eq!(t.contains_key("tst".chars()), false);
+        assert_eq!(t.contains_key("tst".bytes()), false);
     })
 }
 
@@ -74,12 +74,12 @@ fn trie_massive_match(b: &mut Bencher) {
     let keys = generate_keys();
 
     for key in &keys {
-        t.insert(key.chars(), key.clone());
+        t.insert(key.bytes(), key.clone());
     }
 
     b.iter(|| {
         for key in &keys {
-            assert_eq!(t.contains_key(key.chars()), true);
+            assert_eq!(t.contains_key(key.bytes()), true);
         }
     })
 }
@@ -91,12 +91,12 @@ fn trie_massive_mismatch_on_0(b: &mut Bencher) {
     let keys = generate_keys();
 
     for key in &keys {
-        t.insert(key.chars(), key.clone());
+        t.insert(key.bytes(), key.clone());
     }
 
     b.iter(|| {
         for _ in 0..keys.len() {
-            assert_eq!(t.contains_key(mismatching.chars()), false);
+            assert_eq!(t.contains_key(mismatching.bytes()), false);
         }
     })
 }
@@ -108,12 +108,12 @@ fn trie_massive_mismatch_on_1(b: &mut Bencher) {
     let keys = generate_keys();
 
     for key in &keys {
-        t.insert(key.chars(), key.clone());
+        t.insert(key.bytes(), key.clone());
     }
 
     b.iter(|| {
         for _ in 0..keys.len() {
-            assert_eq!(t.contains_key(mismatching.chars()), false);
+            assert_eq!(t.contains_key(mismatching.bytes()), false);
         }
     })
 }
@@ -125,12 +125,12 @@ fn trie_massive_mismatch_on_2(b: &mut Bencher) {
     let keys = generate_keys();
 
     for key in &keys {
-        t.insert(key.chars(), key.clone());
+        t.insert(key.bytes(), key.clone());
     }
 
     b.iter(|| {
         for _ in 0..keys.len() {
-            assert_eq!(t.contains_key(mismatching.chars()), false);
+            assert_eq!(t.contains_key(mismatching.bytes()), false);
         }
     })
 }
@@ -142,12 +142,12 @@ fn trie_massive_mismatch_on_3(b: &mut Bencher) {
     let keys = generate_keys();
 
     for key in &keys {
-        t.insert(key.chars(), key.clone());
+        t.insert(key.bytes(), key.clone());
     }
 
     b.iter(|| {
         for _ in 0..keys.len() {
-            assert_eq!(t.contains_key(mismatching.chars()), false);
+            assert_eq!(t.contains_key(mismatching.bytes()), false);
         }
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,18 +46,18 @@
 //!
 //! let mut t = Trie::new();
 //!
-//! t.insert("this".chars(), 1);
-//! t.insert("trie".chars(), 2);
-//! t.insert("contains".chars(), 3);
-//! t.insert("a".chars(), 4);
-//! t.insert("number".chars(), 5);
-//! t.insert("of".chars(), 6);
-//! t.insert("words".chars(), 7);
+//! t.insert("this".bytes(), 1);
+//! t.insert("trie".bytes(), 2);
+//! t.insert("contains".bytes(), 3);
+//! t.insert("a".bytes(), 4);
+//! t.insert("number".bytes(), 5);
+//! t.insert("of".bytes(), 6);
+//! t.insert("words".bytes(), 7);
 //!
-//! assert_eq!(t.contains_key("number".chars()), true);
-//! assert_eq!(t.contains_key("not_existing_key".chars()), false);
-//! assert_eq!(t.get_value("words".chars()), Some(7));
-//! assert_eq!(t.get_value("none".chars()), None);
+//! assert_eq!(t.contains_key("number".bytes()), true);
+//! assert_eq!(t.contains_key("not_existing_key".bytes()), false);
+//! assert_eq!(t.get_value("words".bytes()), Some(7));
+//! assert_eq!(t.get_value("none".bytes()), None);
 //! ```
 
 mod trie_node;
@@ -111,7 +111,7 @@ impl<T: Eq + Ord + Clone, U: Clone> Trie<T, U> {
     /// use gtrie::Trie;
     ///
     /// let mut t = Trie::new();
-    /// let data = "test".chars();
+    /// let data = "test".bytes();
     ///
     /// t.insert(data, 42);
     /// assert_eq!(t.is_empty(), false);
@@ -155,7 +155,7 @@ impl<T: Eq + Ord + Clone, U: Clone> Trie<T, U> {
     /// use gtrie::Trie;
     ///
     /// let mut t = Trie::new();
-    /// let data = "test".chars();
+    /// let data = "test".bytes();
     ///
     /// t.insert(data, String::from("test"));
     /// t.clear();
@@ -174,8 +174,8 @@ impl<T: Eq + Ord + Clone, U: Clone> Trie<T, U> {
     /// use gtrie::Trie;
     ///
     /// let mut t = Trie::new();
-    /// let data = "test".chars();
-    /// let another_data = "notintest".chars();
+    /// let data = "test".bytes();
+    /// let another_data = "notintest".bytes();
     ///
     /// t.insert(data.clone(), 42);
     ///
@@ -208,8 +208,8 @@ impl<T: Eq + Ord + Clone, U: Clone> Trie<T, U> {
     /// use gtrie::Trie;
     ///
     /// let mut t = Trie::new();
-    /// let data = "test".chars();
-    /// let another_data = "notintest".chars();
+    /// let data = "test".bytes();
+    /// let another_data = "notintest".bytes();
     ///
     /// t.insert(data.clone(), 42);
     ///
@@ -232,8 +232,8 @@ impl<T: Eq + Ord + Clone, U: Clone> Trie<T, U> {
     /// use gtrie::Trie;
     ///
     /// let mut t = Trie::new();
-    /// let data = "test".chars();
-    /// let another_data = "notintest".chars();
+    /// let data = "test".bytes();
+    /// let another_data = "notintest".bytes();
     ///
     /// t.insert(data.clone(), 42);
     ///

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -12,7 +12,7 @@ mod tests {
     #[test]
     fn add_word_to_trie() {
         let mut t = Trie::new();
-        t.insert("test".chars(), String::from("test"));
+        t.insert("test".bytes(), String::from("test"));
 
         assert_eq!(t.is_empty(), false);
     }
@@ -20,9 +20,9 @@ mod tests {
     #[test]
     fn contains_key_test() {
         let mut t = Trie::new();
-        let test = "test".chars();
-        let tes = "tes".chars();
-        let notintest = "notintest".chars();
+        let test = "test".bytes();
+        let tes = "tes".bytes();
+        let notintest = "notintest".bytes();
 
         t.insert(test.clone(), String::from("test"));
 
@@ -35,9 +35,9 @@ mod tests {
     #[test]
     fn contains_key_sub_path_test() {
         let mut t = Trie::new();
-        let test = "test".chars();
-        let tes = "tes".chars();
-        let notintest = "notintest".chars();
+        let test = "test".bytes();
+        let tes = "tes".bytes();
+        let notintest = "notintest".bytes();
 
         t.insert(test.clone(), String::from("test"));
         t.insert(tes.clone(), String::from("tes"));
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn clear_test() {
         let mut t = Trie::new();
-        let data = "test".chars();
+        let data = "test".bytes();
 
         t.insert(data.clone(), String::from("test"));
 


### PR DESCRIPTION
None of the current examples or benchmarks need to work with Unicode
characters; byte tries perform much better.